### PR TITLE
Improves docker build performance and fix issue related to tsc build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 node_modules
 coverage
+dist
 .git
 .husky
+.editorconfig
 *.log
 */__tests__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
+### 1. Installing production dependencies
+
 FROM node:14 AS build-env-modules
-ADD . /app
+# Avoids adding src folder, so docker will use existing cache if nothing changed
+COPY package.json yarn.lock /app/
 WORKDIR /app
 # Ignoring devDependencies for the node_modules that will be added in the production image
 RUN yarn install --prod
 
+### 2. Building application (from TypeScript to JavaScript)
+
 FROM node:14 AS build-env-dist
-ADD . /app
+# Avoids adding src folder, so docker will use existing cache if nothing changed
+COPY package.json yarn.lock /app/
 WORKDIR /app
 # Installing devDependencies to build the js files
 RUN yarn install
+
+COPY . /app/
 RUN yarn build
+
+### 3. Building production image with required files only
 
 # Building the image from distroless to obtain a smaller image for production
 FROM gcr.io/distroless/nodejs:14
@@ -17,4 +27,4 @@ COPY --from=build-env-modules /app/node_modules /app/node_modules
 COPY --from=build-env-dist /app/dist /app/dist
 WORKDIR /app
 EXPOSE 8080
-CMD [ "./dist/index.js" ]
+CMD [ "dist/index.js" ]

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"],
-  "exclude": []
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "target": "esnext"
-  }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js"],
+  "exclude": []
 }


### PR DESCRIPTION
### Docker build performance
* Docker uses cache to build image layers. If any file has changed, it invalidates the cache. `yarn install` was being executed every time a file from `src` was changing, and it was taking a long time. This change in the `Dockerfile` changes build time from 2 minutes to 15 seconds when `package.json` is not changed.

### tsc issue
* For some reason, the command `yarn build` (which just runs `tsc`) on the image build was generating `js` files in `dist/src` instead of `dist`. The same behavior was also happening  on my laptop when running `tsc` instead of `yarn build`. Moving the `include` and `exclude` attributes to `tsconfig.json` fixed the problem.