### PR TITLE
[IOAP-399] Adds step to commit new app version number in CI process

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -55,6 +55,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          # This will checkout the PR branch instead of refs/pull/:pr_id/merge
+          # It is necessary to avoid a detached HEAD when trying to push updates to the branch
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: set-version-visibility-to-unpublished
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -49,7 +49,7 @@ jobs:
     if: ${{ success() }}
 
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -98,3 +98,4 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "Increments app version"
           git push
+

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -74,3 +74,23 @@ jobs:
           docker-token: ${{ secrets.DOCKER_TOKEN }}
           version-visibility: ${{ env.APP_VERSION_VISIBILITY }}
           version-increment-type: 'patch'
+
+      - name: Get app metadata
+        id: app-metadata
+        uses: vtex/app-metadata-action@main
+        with:
+          version-visibility: ${{ env.APP_VERSION_VISIBILITY }}
+          version-increment-type: 'patch'
+
+      - name: Update app files to use the published version
+        uses: mikefarah/yq@v4.22.1
+        with:
+          cmd: yq -i '.version |= "${{steps.app-metadata.outputs.next-app-version}}"' vtex.yml
+
+      - name: Push new version to repository
+        run: |
+          git config --global user.name 'App CI/CD bot'
+          git config --global user.email '<>'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Increments app version"
+          git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-app-node-server-template",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "scripts": {
     "start": "tsc && NODE_ENV=production node dist/index.js",
     "build": "tsc",

--- a/src/__tests__/middlewares/fetch-app-token-middleware.test.ts
+++ b/src/__tests__/middlewares/fetch-app-token-middleware.test.ts
@@ -46,7 +46,6 @@ describe('Fetch App Token Middleware', () => {
       'x-vtex-api-appkey': thisAppKey,
       'x-vtex-api-apptoken': thisAppToken,
     })
-    expect(ctx.header?.['x-vtex-account']).toBe(accountName)
     expect(ctx.header?.['x-vtex-credential']).toBe(authorizationToken)
   })
 })

--- a/src/middlewares/app-routes.middleware.ts
+++ b/src/middlewares/app-routes.middleware.ts
@@ -14,6 +14,8 @@ import koaCompose from 'koa-compose'
 import { nameSpanOperationMiddleware } from './tracing.middleware'
 import { createContextMiddleware } from './context.middleware'
 import { globalLimiter } from './default-configuration.constants'
+import { fetchAppTokenMiddleware } from './fetch-app-token.middleware'
+import { validateExpectedHeaders } from './validate-expected-headers.middleware'
 
 export const createAppRoutesMiddleware = <T extends IOClients>(
   clientsConfig: ClientsConfig<T>
@@ -21,6 +23,8 @@ export const createAppRoutesMiddleware = <T extends IOClients>(
   const { implementation, options } = clientsConfig
 
   const middlewares = [
+    validateExpectedHeaders,
+    fetchAppTokenMiddleware,
     nameSpanOperationMiddleware(),
     createContextMiddleware(),
     cancellationToken,

--- a/src/middlewares/fetch-app-token.middleware.ts
+++ b/src/middlewares/fetch-app-token.middleware.ts
@@ -8,7 +8,7 @@ export const fetchAppTokenMiddleware = async (ctx: Context, next: Next) => {
     'x-vtex-api-apptoken': process.env.VTEX_APP_TOKEN ?? '',
   }
 
-  const accountName = ctx.headers['x-vtex-account'] as string
+  const accountName = ctx.headers[ACCOUNT_HEADER] as string
 
   try {
     const request = await axios.get(`auth/accounts/${accountName}/jwt`, {
@@ -18,7 +18,6 @@ export const fetchAppTokenMiddleware = async (ctx: Context, next: Next) => {
     })
 
     // set request header for future middlewares
-    ctx.header[ACCOUNT_HEADER] = accountName
     ctx.header[CREDENTIAL_HEADER] = request.data.jwt
   } catch (e) {
     console.error(e)

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -15,7 +15,6 @@ import {
   addExecuteMiddlewaresForRouteType,
   MiddlewaresByRouteType,
 } from './route-type.middleware'
-import { fetchAppTokenMiddleware } from './fetch-app-token.middleware'
 
 export const defaultMiddlewares = (clients: ClientsConfig = defaultClients) => {
   const tracer = TracerSingleton.getTracer()
@@ -33,7 +32,6 @@ export const defaultMiddlewares = (clients: ClientsConfig = defaultClients) => {
     cors(),
     json(),
     bodyParser(),
-    fetchAppTokenMiddleware,
     addTracingMiddleware(tracer),
     addExecuteMiddlewaresForRouteType(middlewaresForRouteType),
   ]

--- a/src/middlewares/validate-expected-headers.middleware.ts
+++ b/src/middlewares/validate-expected-headers.middleware.ts
@@ -1,0 +1,10 @@
+import type { Context, Next } from 'koa'
+import { ACCOUNT_HEADER } from '@vtex/api'
+
+export const validateExpectedHeaders = async (ctx: Context, next: Next) => {
+  if (!ctx.header[ACCOUNT_HEADER]) {
+    ctx.throw(400, `Missing ${ACCOUNT_HEADER} header`)
+  }
+
+  await next()
+}

--- a/vtex.yml
+++ b/vtex.yml
@@ -1,10 +1,9 @@
 name: starter-node-service
 vendor: extensions
 version: 0.0.17
-
 services:
-- name: service
-  folder: ./
-  image-name: vtex-docker/starter-node-service
-  public: true
-  # Check https://tinyurl.com/ujm8kmuv for optional params - TODO point this link to public doc
+  - name: service
+    folder: ./
+    image-name: vtex-docker/starter-node-service
+    public: true
+    # Check https://tinyurl.com/ujm8kmuv for optional params - TODO point this link to public doc

--- a/vtex.yml
+++ b/vtex.yml
@@ -1,6 +1,6 @@
 name: starter-node-service
 vendor: extensions
-version: 0.0.17
+version: 0.0.18-4ddad3f.0
 services:
   - name: service
     folder: ./

--- a/vtex.yml
+++ b/vtex.yml
@@ -1,6 +1,6 @@
 name: starter-node-service
 vendor: extensions
-version: 0.0.16
+version: 0.0.17
 
 services:
 - name: service


### PR DESCRIPTION
* With this change, every change to a PR or to the main branch will trigger a commit in the same branch to update the app version number
* At this point the changes are all added to the workflow, but I'll probably move them to an action after working on [this other issue](https://vtex-dev.atlassian.net/browse/IOAP-400)
* The test of this change can be seen in this PR itself. The [5th commit](https://github.com/vtex-apps/starter.node-service/pull/13/commits/e34ec5c2daca90c9266f065150e1575b2e77b957) was performed by Github Actions Workflow