### PR TITLE
[IOAP-400] CI commits change to package.json version update

### DIFF
--- a/.github/actions/publish-to-vtex/action.yml
+++ b/.github/actions/publish-to-vtex/action.yml
@@ -27,20 +27,5 @@ runs:
   using: "composite"
   steps:
 
-    - name: Publish app services to VTEX Docker repository
-      id: publish-docker-images
-      uses: ./.github/actions/publish-docker-image-to-vtex
-      with:
-        docker-user: ${{ inputs.docker-user }}
-        docker-token: ${{ inputs.docker-token }}
-        version-visibility: ${{ inputs.version-visibility }}
-        version-increment-type: ${{ inputs.version-increment-type }}
 
-    - name: Release the current app version to VTEX
-      id: release-app-staging
-      uses: ./.github/actions/publish-app-version-to-vtex
-      with:
-        vtex-app-key: ${{ inputs.vtex-app-key }}
-        vtex-app-token: ${{ inputs.vtex-app-token }}
-        version-visibility: ${{ inputs.version-visibility }}
-        version-increment-type: ${{ inputs.version-increment-type }}
+

--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: '*'
 
+env:
+  APP_VERSION_INCREMENT_TYPE: patch
+
 jobs:
   test:
     name: lint, test, and build
@@ -41,16 +44,12 @@ jobs:
       - run: yarn run build
         working-directory: ${{ env.WORK_DIR }}
 
-  publish-on-success:
+  publish-docker-image:
 
     runs-on: ubuntu-latest
 
     needs: test
     if: ${{ success() }}
-
-    permissions:
-      contents: write
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -68,28 +67,69 @@ jobs:
         if: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
         run: echo "APP_VERSION_VISIBILITY=development" >> $GITHUB_ENV
 
-      - name: Publish app version to VTEX
-        id: publish-to-vtex
-        uses: ./.github/actions/publish-to-vtex
+      - name: Publish app services to VTEX Docker repository
+        id: publish-docker-images
+        uses: ./.github/actions/publish-docker-image-to-vtex
         with:
-          vtex-app-key: ${{ secrets.VTEX_APP_KEY }}
-          vtex-app-token: ${{ secrets.VTEX_APP_TOKEN }}
           docker-user: ${{ secrets.DOCKER_USER }}
           docker-token: ${{ secrets.DOCKER_TOKEN }}
           version-visibility: ${{ env.APP_VERSION_VISIBILITY }}
-          version-increment-type: 'patch'
+          version-increment-type: ${{ env.APP_VERSION_INCREMENT_TYPE }}
+
+  publish-app-version:
+
+    runs-on: ubuntu-latest
+
+    needs: publish-docker-image
+    if: ${{ success() }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # This will checkout the PR branch instead of refs/pull/:pr_id/merge
+          # It is necessary to avoid a detached HEAD when trying to push updates to the branch
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: set-version-visibility-to-unpublished
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        run: echo "APP_VERSION_VISIBILITY=unpublished" >> $GITHUB_ENV
+
+      - name: set-version-visibility-to-development
+        if: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
+        run: echo "APP_VERSION_VISIBILITY=development" >> $GITHUB_ENV
+
+      - name: Release the current app version to VTEX
+        id: release-app-version
+        uses: ./.github/actions/publish-app-version-to-vtex
+        with:
+          vtex-app-key: ${{ secrets.VTEX_APP_KEY }}
+          vtex-app-token: ${{ secrets.VTEX_APP_TOKEN }}
+          version-visibility: ${{ env.APP_VERSION_VISIBILITY }}
+          version-increment-type: ${{ env.APP_VERSION_INCREMENT_TYPE }}
 
       - name: Get app metadata
         id: app-metadata
         uses: vtex/app-metadata-action@main
         with:
           version-visibility: ${{ env.APP_VERSION_VISIBILITY }}
-          version-increment-type: 'patch'
+          version-increment-type: ${{ env.APP_VERSION_INCREMENT_TYPE }}
 
-      - name: Update app files to use the published version
+      - name: Update vtex.yml to use the published version
         uses: mikefarah/yq@v4.22.1
         with:
           cmd: yq -i '.version |= "${{steps.app-metadata.outputs.next-app-version}}"' vtex.yml
+
+      - name: Export env.WORK_DIR as the service path
+        run: echo "WORK_DIR=${{ steps.app-metadata.outputs.frontend-folder }}" >> $GITHUB_ENV
+
+      - name: Update frontend package version
+        if: ${{ env.WORK_DIR != null && env.WORK_DIR != '' }}
+        run: yarn version --new-version ${{steps.app-metadata.outputs.next-app-version}} --no-git-tag-version
+        working-directory: ${{ env.WORK_DIR }}
 
       - name: Push new version to repository
         run: |
@@ -98,4 +138,3 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "Increments app version"
           git push
-

--- a/vtex.yml
+++ b/vtex.yml
@@ -1,6 +1,6 @@
 name: starter-node-service
 vendor: extensions
-version: 0.0.18-fee86f7.0
+version: 0.0.19-4820316.0
 services:
   - name: service
     folder: ./

--- a/vtex.yml
+++ b/vtex.yml
@@ -1,6 +1,6 @@
 name: starter-node-service
 vendor: extensions
-version: 0.0.17
+version: 0.0.18-fee86f7.0
 services:
   - name: service
     folder: ./


### PR DESCRIPTION
* After other jobs succeed, the version in the frontend modules package.json will be modified along with vtex.yml file and committed to the PR branch
* The old workflow job `publish-on-success` has been split in two parts: `publish-docker-image` and `publish-app-version`, where the latter is responsible for calling Apps Framework API. This was the way I found to add the change in the package.json together with vtex.yml change. I think it will also make it easier to split jobs to only call Apps Framework API when everything else suceeds